### PR TITLE
fix the bug of one digit fraction

### DIFF
--- a/ttml2bdnxml.rb
+++ b/ttml2bdnxml.rb
@@ -24,7 +24,7 @@ def subtitles(filename)
 end
 
 def f(time)
-  time.gsub(".", ":")[0..-2]
+  time.gsub(".", ":").slice(0, 11)
 end
 
 def layout_subtitle(event)


### PR DESCRIPTION
fix https://github.com/cuzic/hardsub-netflix/issues/16

The code expected the fraction has three digits.

But some ttml xml have only one fraction digit.

This fixes to accept the ttml.

![image](https://user-images.githubusercontent.com/34621/72765883-fdf55800-3c31-11ea-993a-d5f5f9752f63.png)
