### PR TITLE
fix the bug of converting failure

### DIFF
--- a/ttml2bdnxml.rb
+++ b/ttml2bdnxml.rb
@@ -148,10 +148,8 @@ class Converter
   def merge(events)
     if events.size == 1
       event = events.first
-      if event.height < event.width && 400 < event.y
-        FileUtils.cp(source(event), dest(event))
-        return event
-      end
+      FileUtils.cp(source(event), dest(event))
+      return event
     end
 
     delta_x, top_y, bottom_y = convert(events)


### PR DESCRIPTION
the bug fixed

when
 - an event has more than two subtitle images at once
 - one of them is lower than 400 px top position
then
 - ttml => sub/idx converting failed

